### PR TITLE
Implement StackOverflow quota degradation strategy

### DIFF
--- a/docs/tasks/2-06.md
+++ b/docs/tasks/2-06.md
@@ -1,0 +1,9 @@
+**Implement StackOverflow quota degradation strategy**
+  - **Cursor prompt:**  
+    - Add a policy: if SO budget exhausted, skip `get_content` and only keep `so_search` snippets or fallback to Wikipedia/textbooks. Expose a reason in the response metadata.
+    - Use all cursor rules from `.cursor/rules`.
+    - Automatically run unit tests after task is complete.
+    - Automatically run format and style tools (80-code-style-python.mdc) after test is complete.”
+  - **Definition of Done:** 
+    - system still answers without crashing when SO is unavailable/limited.
+    - all unit tests must pass successfully.

--- a/src/packages/mcp_clients/tool_wrappers.py
+++ b/src/packages/mcp_clients/tool_wrappers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Literal, Mapping, Sequence, TypedDict
+from typing import Any, Literal, Mapping, NotRequired, Sequence, TypedDict
 
 from .client_factory import McpServerTools, McpToolHandle
 from .interceptors.audit import audit_tool_call
@@ -35,12 +35,18 @@ class StackOverflowItem(TypedDict, total=False):
     content: str
 
 
+class ToolResponseMetadata(TypedDict, total=False):
+    degraded: bool
+    reason: str
+
+
 class StackOverflowToolResult(TypedDict):
     source: Literal["stackoverflow"]
     tool: Literal["so_search", "get_content"]
     ok: bool
     items: list[StackOverflowItem]
     raw: Mapping[str, Any]
+    metadata: NotRequired[ToolResponseMetadata]
 
 
 class WikipediaItem(TypedDict, total=False):

--- a/src/packages/orchestrator/retrieval.py
+++ b/src/packages/orchestrator/retrieval.py
@@ -2,12 +2,18 @@ from __future__ import annotations
 
 from typing import Sequence
 
+from packages.mcp_clients.interceptors.budget import (
+    ToolBudgetExceeded,
+    ToolBudgetManager,
+)
 from packages.mcp_clients.tool_wrappers import (
     StackOverflowToolResult,
     StackOverflowToolset,
     so_get_content,
     so_search,
 )
+
+_SO_BUDGET_REASON = "stackoverflow_budget_exhausted"
 
 
 def retrieve_stackoverflow(
@@ -16,15 +22,83 @@ def retrieve_stackoverflow(
     query: str,
     tags: Sequence[str] | None = None,
     max_items: int = 3,
+    budget_manager: ToolBudgetManager | None = None,
 ) -> list[StackOverflowToolResult]:
     results: list[StackOverflowToolResult] = []
-    search_result = so_search(tools, query=query, tags=tags, limit=max_items)
+    if budget_manager is not None:
+        try:
+            budget_manager.assert_can_call(tools.search)
+        except ToolBudgetExceeded:
+            return [
+                _budget_degraded_result(
+                    ok=False,
+                    reason=_SO_BUDGET_REASON,
+                )
+            ]
+
+    search_result: StackOverflowToolResult | None = None
+    try:
+        search_result = so_search(tools, query=query, tags=tags, limit=max_items)
+        if budget_manager is not None:
+            budget_manager.check_payload_size(search_result)
+    except ToolBudgetExceeded:
+        if search_result is None:
+            return [
+                _budget_degraded_result(
+                    ok=False,
+                    reason=_SO_BUDGET_REASON,
+                )
+            ]
+        _attach_budget_metadata(search_result, _SO_BUDGET_REASON)
+        results.append(search_result)
+        return results
+    finally:
+        if budget_manager is not None:
+            budget_manager.record_call(tools.search)
+
     results.append(search_result)
 
     for item in search_result["items"][:max_items]:
         question_id = item.get("question_id")
         if not question_id:
             continue
-        results.append(so_get_content(tools, question_id=question_id))
+        if budget_manager is not None:
+            try:
+                budget_manager.assert_can_call(tools.get_content)
+            except ToolBudgetExceeded:
+                _attach_budget_metadata(search_result, _SO_BUDGET_REASON)
+                break
+        content_result: StackOverflowToolResult | None = None
+        try:
+            content_result = so_get_content(tools, question_id=question_id)
+            if budget_manager is not None:
+                budget_manager.check_payload_size(content_result)
+        except ToolBudgetExceeded:
+            _attach_budget_metadata(search_result, _SO_BUDGET_REASON)
+            break
+        finally:
+            if budget_manager is not None:
+                budget_manager.record_call(tools.get_content)
+
+        if content_result is not None:
+            results.append(content_result)
 
     return results
+
+
+def _attach_budget_metadata(
+    result: StackOverflowToolResult, reason: str
+) -> StackOverflowToolResult:
+    result["metadata"] = {"degraded": True, "reason": reason}
+    return result
+
+
+def _budget_degraded_result(*, ok: bool, reason: str) -> StackOverflowToolResult:
+    return {
+        "source": "stackoverflow",
+        "tool": "so_search",
+        "ok": ok,
+        "items": [],
+        "raw": {},
+        "metadata": {"degraded": True, "reason": reason},
+    }

--- a/src/tests/unit/test_retrieval.py
+++ b/src/tests/unit/test_retrieval.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import unittest
 from typing import Any, Mapping
 
+from packages.mcp_clients.interceptors import ToolBudgetLimits, ToolBudgetManager
 from packages.mcp_clients.tool_wrappers import stackoverflow_tools
 from packages.orchestrator.retrieval import retrieve_stackoverflow
 
@@ -82,6 +83,50 @@ class RetrievalTests(unittest.TestCase):
             [{"question_id": "1"}, {"question_id": "2"}],
         )
         self.assertEqual(len(results), 3)
+
+    def test_retrieve_stackoverflow_skips_content_when_budget_exhausted(self) -> None:
+        tools = stackoverflow_tools(_FakeTools())
+        budget = ToolBudgetManager(limits=ToolBudgetLimits(total_calls=1))
+
+        results = retrieve_stackoverflow(
+            tools,
+            query="unit test",
+            tags=None,
+            max_items=2,
+            budget_manager=budget,
+        )
+
+        self.assertEqual(tools.search.calls, [{"query": "unit test", "limit": 2}])
+        self.assertEqual(tools.get_content.calls, [])
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["tool"], "so_search")
+        self.assertTrue(results[0]["metadata"]["degraded"])
+        self.assertEqual(
+            results[0]["metadata"]["reason"], "stackoverflow_budget_exhausted"
+        )
+
+    def test_retrieve_stackoverflow_returns_metadata_when_budget_blocks_search(
+        self,
+    ) -> None:
+        tools = stackoverflow_tools(_FakeTools())
+        budget = ToolBudgetManager(limits=ToolBudgetLimits(total_calls=0))
+
+        results = retrieve_stackoverflow(
+            tools,
+            query="unit test",
+            tags=None,
+            max_items=2,
+            budget_manager=budget,
+        )
+
+        self.assertEqual(tools.search.calls, [])
+        self.assertEqual(tools.get_content.calls, [])
+        self.assertEqual(len(results), 1)
+        self.assertFalse(results[0]["ok"])
+        self.assertTrue(results[0]["metadata"]["degraded"])
+        self.assertEqual(
+            results[0]["metadata"]["reason"], "stackoverflow_budget_exhausted"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Enhanced the `retrieve_stackoverflow` function to incorporate budget management, allowing for controlled tool calls based on available budget.
- Added metadata handling for degraded results when budget limits are exceeded.
- Introduced unit tests to validate behavior when budget is exhausted, ensuring proper handling of search and content retrieval under budget constraints.
- Updated `tool_wrappers.py` to include new metadata structure for tool responses.