### PR TITLE
Implemented a deterministic plan node

### DIFF
--- a/.cursor/rules/80-code-style-python.mdc
+++ b/.cursor/rules/80-code-style-python.mdc
@@ -41,6 +41,8 @@ alwaysApply: false
 - Prefer progressive strictness:
   - Start with strong warnings (e.g., `warn_unused_ignores`, `warn_return_any`), then tighten module-by-module.
 - Use per-module overrides for third-party libraries lacking stubs (document why).
+- Run `mypy` against the configured `files` scope in `pyproject.toml` after adding new types or updating public APIs.
+- If `mypy` failures are due to missing stubs, add a scoped override or a targeted `# type: ignore[...]` with a brief justification.
 
 ## 7) Patterns to follow
 - Prefer `pathlib` over raw string paths.
@@ -50,4 +52,4 @@ alwaysApply: false
 ## 8) Definition of "done" for Python changes
 - `ruff check` passes
 - formatting passes (ruff format or black, depending on project choice)
-- mypy passes for touched modules (or justified ignore with comment + issue link)
+- `mypy` passes for touched modules (or justified ignore with comment + issue link)

--- a/docs/tasks/3-01.md
+++ b/docs/tasks/3-01.md
@@ -3,7 +3,7 @@
   - **Cursor prompt:**  
     - Create a Pydantic (or TypedDict) state model: question, student_context, subject, intent, tool_budget, retrieved_items, evidence, draft_answer, final_answer, safety_flags, diagnostics.
     - Automatically run unit tests after task is complete.
-    - Automatically run format and style tools by using `.cursor/rules/80-code-style-python.mdc` after test is complete.”
+    - Automatically run format and style tools by using `.cursor/rules/80-code-style-python.mdc` after test is complete.
   - **Definition of Done:** 
     - all nodes read/write through the state model.
     - all unit tests must pass successfully.

--- a/docs/tasks/3-03.md
+++ b/docs/tasks/3-03.md
@@ -1,0 +1,9 @@
+**Implement `plan` node**
+  - File: `packages/orchestrator/src/graph/nodes/plan.py`
+  - **Cursor prompt:**  
+    - Implement a planning node that builds a retrieval plan: which sources to query (SO/Wikipedia/textbooks) and search queries. Use `config/subjects.yaml` and `policies.yaml`.
+    - Automatically run unit tests after task is complete.
+    - Automatically run format and style tools by using `.cursor/rules/80-code-style-python.mdc` after test is complete.
+  - **Definition of Done:** 
+    - plan describes parallelizable tool calls + priorities.
+    - all unit tests and linters (ruff, myry) must pass successfully.

--- a/src/config/policies.yaml
+++ b/src/config/policies.yaml
@@ -1,0 +1,6 @@
+allow_sources:
+  - wikipedia
+  - stackoverflow
+  - textbooks
+
+deny_sources: []

--- a/src/config/subjects.yaml
+++ b/src/config/subjects.yaml
@@ -1,0 +1,40 @@
+default:
+  sources:
+    - wikipedia
+    - textbooks
+
+programming:
+  sources:
+    - stackoverflow
+    - wikipedia
+    - textbooks
+  intents:
+    debug:
+      sources:
+        - stackoverflow
+        - wikipedia
+        - textbooks
+    solve:
+      sources:
+        - stackoverflow
+        - wikipedia
+        - textbooks
+    explain:
+      sources:
+        - wikipedia
+        - stackoverflow
+        - textbooks
+
+math:
+  sources:
+    - textbooks
+    - wikipedia
+  intents:
+    solve:
+      sources:
+        - textbooks
+        - wikipedia
+    explain:
+      sources:
+        - wikipedia
+        - textbooks

--- a/src/packages/orchestrator/graph/__init__.py
+++ b/src/packages/orchestrator/graph/__init__.py
@@ -1,3 +1,19 @@
-from .state import EvidenceItem, OrchestratorState, StudentContext, ToolBudget
+from .state import (
+    EvidenceItem,
+    OrchestratorState,
+    PlanCall,
+    RetrievalPlan,
+    SourceName,
+    StudentContext,
+    ToolBudget,
+)
 
-__all__ = ["EvidenceItem", "OrchestratorState", "StudentContext", "ToolBudget"]
+__all__ = [
+    "EvidenceItem",
+    "OrchestratorState",
+    "PlanCall",
+    "RetrievalPlan",
+    "SourceName",
+    "StudentContext",
+    "ToolBudget",
+]

--- a/src/packages/orchestrator/graph/nodes/__init__.py
+++ b/src/packages/orchestrator/graph/nodes/__init__.py
@@ -1,3 +1,4 @@
 from .classify import classify
+from .plan import plan
 
-__all__ = ["classify"]
+__all__ = ["classify", "plan"]

--- a/src/packages/orchestrator/graph/nodes/plan.py
+++ b/src/packages/orchestrator/graph/nodes/plan.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping, cast
+
+from packages.orchestrator.graph.state import (
+    OrchestratorState,
+    PlanCall,
+    RetrievalPlan,
+    SourceName,
+)
+
+
+_DEFAULT_SOURCES: dict[tuple[str, str], list[SourceName]] = {
+    ("programming", "debug"): ["stackoverflow", "wikipedia", "textbooks"],
+    ("programming", "solve"): ["stackoverflow", "wikipedia", "textbooks"],
+    ("programming", "explain"): ["stackoverflow", "wikipedia", "textbooks"],
+    ("math", "solve"): ["textbooks", "wikipedia"],
+    ("math", "explain"): ["wikipedia", "textbooks"],
+    ("general", "explain"): ["wikipedia", "textbooks"],
+    ("general", "solve"): ["wikipedia", "textbooks"],
+}
+
+_SOURCE_TO_TOOL: dict[SourceName, str] = {
+    "stackoverflow": "so_search",
+    "wikipedia": "wikipedia_search",
+    "textbooks": "textbooks_search",
+}
+_SOURCE_NAMES = set(_SOURCE_TO_TOOL.keys())
+
+
+def plan(state: Mapping[str, object]) -> OrchestratorState:
+    question = str(state.get("question", "")).strip()
+    subject = str(state.get("subject", "general")).strip().lower() or "general"
+    intent = str(state.get("intent", "explain")).strip().lower() or "explain"
+
+    subjects_cfg = _load_config("subjects.yaml")
+    policies_cfg = _load_config("policies.yaml")
+
+    sources = _determine_sources(subject, intent, subjects_cfg, policies_cfg)
+    calls = _build_calls(question, subject, intent, sources)
+
+    retrieval_plan: RetrievalPlan = {
+        "calls": calls,
+        "priority_order": sources,
+        "parallelizable": True,
+    }
+
+    return {"retrieval_plan": retrieval_plan}
+
+
+def _build_calls(
+    question: str,
+    subject: str,
+    intent: str,
+    sources: list[SourceName],
+) -> list[PlanCall]:
+    calls: list[PlanCall] = []
+    query = _build_query(question, subject, intent)
+    for priority, source in enumerate(sources, start=1):
+        tool = _SOURCE_TO_TOOL[source]
+        calls.append(
+            {
+                "source": source,
+                "tool": tool,
+                "query": query,
+                "priority": priority,
+            }
+        )
+    return calls
+
+
+def _build_query(question: str, subject: str, intent: str) -> str:
+    if question:
+        return question
+    if subject != "general":
+        return f"{intent} {subject}".strip()
+    return intent
+
+
+def _determine_sources(
+    subject: str,
+    intent: str,
+    subjects_cfg: dict[str, object],
+    policies_cfg: dict[str, object],
+) -> list[SourceName]:
+    sources = _lookup_subject_sources(subject, intent, subjects_cfg)
+    if not sources:
+        sources = _DEFAULT_SOURCES.get((subject, intent)) or _DEFAULT_SOURCES.get(
+            (subject, "explain"),
+            ["wikipedia"],
+        )
+
+    allow_list = _get_list_value(policies_cfg, "allow_sources")
+    if allow_list:
+        sources = [source for source in sources if source in allow_list]
+
+    deny_list = _get_list_value(policies_cfg, "deny_sources")
+    if deny_list:
+        sources = [source for source in sources if source not in deny_list]
+
+    return sources or ["wikipedia"]
+
+
+def _lookup_subject_sources(
+    subject: str,
+    intent: str,
+    subjects_cfg: dict[str, object],
+) -> list[SourceName]:
+    subject_cfg = subjects_cfg.get(subject)
+    if isinstance(subject_cfg, dict):
+        intent_cfg = subject_cfg.get("intents")
+        if isinstance(intent_cfg, dict):
+            sources = intent_cfg.get(intent)
+            if isinstance(sources, list):
+                return _normalize_sources(sources)
+            sources = intent_cfg.get("sources")
+            if isinstance(sources, list):
+                return _normalize_sources(sources)
+        sources = subject_cfg.get("sources")
+        if isinstance(sources, list):
+            return _normalize_sources(sources)
+
+    default_cfg = subjects_cfg.get("default")
+    if isinstance(default_cfg, dict):
+        sources = default_cfg.get("sources")
+        if isinstance(sources, list):
+            return _normalize_sources(sources)
+
+    return []
+
+
+def _get_list_value(config: dict[str, object], key: str) -> list[SourceName]:
+    value = config.get(key)
+    if isinstance(value, list):
+        return _normalize_sources(value)
+    return []
+
+
+def _normalize_sources(values: list[object]) -> list[SourceName]:
+    normalized: list[SourceName] = []
+    for value in values:
+        item = str(value).strip()
+        if item in _SOURCE_NAMES:
+            normalized.append(cast(SourceName, item))
+    return normalized
+
+
+def _load_config(filename: str) -> dict[str, object]:
+    config_path = _config_dir() / filename
+    if not config_path.exists():
+        return {}
+
+    raw = config_path.read_text(encoding="utf-8").strip()
+    if not raw:
+        return {}
+
+    parsed = _try_yaml_load(raw)
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _try_yaml_load(raw: str) -> dict[str, object]:
+    try:
+        import yaml  # type: ignore
+    except ImportError:
+        return _parse_simple_yaml(raw)
+
+    try:
+        loaded = yaml.safe_load(raw)
+    except Exception:
+        return {}
+
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _parse_simple_yaml(raw: str) -> dict[str, object]:
+    parsed: dict[str, object] = {}
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if ":" not in stripped:
+            continue
+        key, value = stripped.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            continue
+        parsed[key] = value
+    return parsed
+
+
+def _config_dir() -> Path:
+    return Path(__file__).resolve().parents[4] / "config"

--- a/src/packages/orchestrator/graph/state.py
+++ b/src/packages/orchestrator/graph/state.py
@@ -40,6 +40,22 @@ class Citation(TypedDict, total=False):
     title: str
 
 
+SourceName = Literal["wikipedia", "stackoverflow", "textbooks"]
+
+
+class PlanCall(TypedDict):
+    source: SourceName
+    tool: str
+    query: str
+    priority: int
+
+
+class RetrievalPlan(TypedDict):
+    calls: list[PlanCall]
+    priority_order: list[SourceName]
+    parallelizable: bool
+
+
 class OrchestratorState(TypedDict, total=False):
     question: str
     student_context: StudentContext
@@ -48,6 +64,7 @@ class OrchestratorState(TypedDict, total=False):
     mode: Literal["coach", "solution_allowed", "hint_only"]
     needs_clarification: bool
     tool_budget: ToolBudget
+    retrieval_plan: RetrievalPlan
     retrieved_items: list[RetrievedItem]
     evidence: list[EvidenceItem]
     draft_answer: str

--- a/src/tests/unit/test_plan_node.py
+++ b/src/tests/unit/test_plan_node.py
@@ -1,0 +1,31 @@
+from packages.orchestrator.graph.nodes.plan import plan
+
+
+def test_plan_programming_debug_defaults() -> None:
+    state = {
+        "question": "My Python code throws a traceback error. How to debug?",
+        "subject": "programming",
+        "intent": "debug",
+    }
+    result = plan(state)
+
+    retrieval_plan = result["retrieval_plan"]
+    assert retrieval_plan["parallelizable"] is True
+    assert retrieval_plan["priority_order"] == [
+        "stackoverflow",
+        "wikipedia",
+        "textbooks",
+    ]
+    assert [call["source"] for call in retrieval_plan["calls"]] == [
+        "stackoverflow",
+        "wikipedia",
+        "textbooks",
+    ]
+
+
+def test_plan_builds_fallback_query() -> None:
+    state = {"question": "", "subject": "math", "intent": "solve"}
+    result = plan(state)
+
+    retrieval_plan = result["retrieval_plan"]
+    assert retrieval_plan["calls"][0]["query"] == "solve math"


### PR DESCRIPTION
Implemented a deterministic plan node that reads config (with safe fallbacks) and emits a retrieval plan with prioritized, parallelizable tool calls.

- Updated `.cursor/rules/80-code-style-python.mdc` to include guidelines for running `mypy` after type updates and handling missing stubs.
- Modified `docs/tasks/3-01.md` for clarity on running format and style tools.
- Introduced `policies.yaml` to define allowed and denied sources for content retrieval.
- Added `subjects.yaml` to specify sources and intents for different subjects.
- Expanded the orchestrator graph's `__init__.py` to include new imports for `PlanCall`, `RetrievalPlan`, and `SourceName`.
- Enhanced `state.py` with new TypedDicts for `PlanCall` and `RetrievalPlan`, and updated `OrchestratorState` to include a retrieval plan.