### PR TITLE
Added prompt templates

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-# Architecture — Homework Helper (LangChain + LangGraph + MCP)
+# Architecture — Homework Helper (LangGraph + MCP)
 
 This document describes the architecture of a “homework helper” assistant: a student asks a question about a subject, the agent retrieves relevant explanations/examples from Wikipedia, StackOverflow, and optional electronic textbooks, then produces a guided, citation-backed answer.
 

--- a/docs/tasks/3-10.md
+++ b/docs/tasks/3-10.md
@@ -1,0 +1,10 @@
+**Add prompt templates**
+  - Files: `packages/orchestrator/src/prompts/system.md`, `synthesis.md`, `self_check.md`, `citation.md`
+  - **Cursor prompt:**  
+    - Create prompt templates enforcing ‘homework coach’ style, citation discipline, and no large verbatim copying from sources.
+    - Always write unit tests for the code in a task.
+    - Automatically run unit tests after task is complete.
+    - Automatically run format and style tools by using `.cursor/rules/80-code-style-python.mdc` after test is complete.
+  - **Definition of Done:** 
+    - prompts are referenced by nodes (no inline prompt strings). 
+    - all unit tests and linters (ruff, mypy) must pass successfully.

--- a/src/packages/orchestrator/graph/nodes/self_check.py
+++ b/src/packages/orchestrator/graph/nodes/self_check.py
@@ -1,17 +1,9 @@
 from __future__ import annotations
 
-import re
 from typing import Mapping, cast
 
 from packages.orchestrator.graph.state import EvidenceItem, OrchestratorState
-
-_SECTION_HEADERS = {
-    "Explanation",
-    "Steps",
-    "Worked Example",
-    "Self-Check Questions",
-    "Sources",
-}
+from packages.orchestrator.prompts import load_prompt, synthesis_headers
 
 
 def self_check(state: Mapping[str, object]) -> OrchestratorState:
@@ -22,7 +14,7 @@ def self_check(state: Mapping[str, object]) -> OrchestratorState:
     diagnostics = _build_diagnostics(unsupported)
 
     if not supported_lines:
-        supported_lines = ["I don't have enough evidence to support an answer yet."]
+        supported_lines = [load_prompt("self_check")]
 
     final_answer = "\n".join(supported_lines).strip()
 
@@ -50,7 +42,8 @@ def _filter_supported_sentences(
         return ([], [])
 
     claim_keys, support_keys = _build_support_keys(evidence)
-    lines = _split_sentences(draft_answer)
+    lines = _split_lines(draft_answer)
+    headers = set(synthesis_headers())
     supported: list[str] = []
     unsupported: list[str] = []
 
@@ -58,7 +51,7 @@ def _filter_supported_sentences(
         stripped = line.strip()
         if not stripped:
             continue
-        if stripped in _SECTION_HEADERS:
+        if stripped in headers:
             supported.append(stripped)
             continue
         if _is_supported(stripped, claim_keys, support_keys):
@@ -91,8 +84,8 @@ def _is_supported(sentence: str, claims: list[str], supports: list[str]) -> bool
     )
 
 
-def _split_sentences(text: str) -> list[str]:
-    return re.split(r"(?<=[.!?])\s+", text.strip())
+def _split_lines(text: str) -> list[str]:
+    return [line.strip() for line in text.splitlines() if line.strip()]
 
 
 def _build_diagnostics(unsupported: list[str]) -> dict[str, list[str]]:

--- a/src/packages/orchestrator/graph/nodes/synthesize.py
+++ b/src/packages/orchestrator/graph/nodes/synthesize.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Mapping, cast
 
 from packages.orchestrator.graph.state import Citation, EvidenceItem, OrchestratorState
+from packages.orchestrator.prompts import load_prompt, render_prompt
 
 
 def synthesize(state: Mapping[str, object]) -> OrchestratorState:
@@ -11,6 +12,7 @@ def synthesize(state: Mapping[str, object]) -> OrchestratorState:
         return {
             "final_answer": _no_evidence_answer(),
             "citations": [],
+            "diagnostics": _prompt_diagnostics(state),
         }
 
     citations = _build_citations(evidence)
@@ -20,24 +22,21 @@ def synthesize(state: Mapping[str, object]) -> OrchestratorState:
     self_check = _build_self_check(evidence)
     sources = _build_sources(citations)
 
-    final_answer = "\n\n".join(
-        [
-            "Explanation",
-            explanation,
-            "Steps",
-            steps,
-            "Worked Example",
-            example,
-            "Self-Check Questions",
-            self_check,
-            "Sources",
-            sources,
-        ]
+    final_answer = render_prompt(
+        "synthesis",
+        {
+            "explanation": explanation,
+            "steps": steps,
+            "example": example,
+            "self_check": self_check,
+            "sources": sources,
+        },
     )
 
     return {
         "final_answer": final_answer,
         "citations": citations,
+        "diagnostics": _prompt_diagnostics(state),
     }
 
 
@@ -97,10 +96,11 @@ def _build_sources(citations: list[Citation]) -> str:
     for index, cite in enumerate(citations, start=1):
         label = cite.get("title") or cite.get("locator") or cite.get("source")
         url = cite.get("url") or cite.get("locator") or ""
-        if url:
-            lines.append(f"- [{index}] {label} — {url}")
-        else:
-            lines.append(f"- [{index}] {label}")
+        line = render_prompt(
+            "citation",
+            {"index": str(index), "title": str(label), "url": str(url)},
+        )
+        lines.append(line.rstrip("— ").rstrip())
     return "\n".join(lines)
 
 
@@ -134,17 +134,20 @@ def _citation_marker(item: EvidenceItem) -> str:
 
 
 def _no_evidence_answer() -> str:
-    return "\n".join(
-        [
-            "Explanation",
-            "I do not have enough evidence yet to answer confidently.",
-            "Steps",
-            "1. Share more context or details about the problem.",
-            "Worked Example",
-            "Example unavailable without sources.",
-            "Self-Check Questions",
-            "- What details are still missing?",
-            "Sources",
-            "- No sources available.",
-        ]
+    return render_prompt(
+        "synthesis",
+        {
+            "explanation": "I do not have enough evidence yet to answer confidently.",
+            "steps": "1. Share more context or details about the problem.",
+            "example": "Example unavailable without sources.",
+            "self_check": "- What details are still missing?",
+            "sources": "- No sources available.",
+        },
     )
+
+
+def _prompt_diagnostics(state: Mapping[str, object]) -> dict[str, object]:
+    diagnostics = state.get("diagnostics")
+    merged = dict(diagnostics) if isinstance(diagnostics, Mapping) else {}
+    merged.setdefault("system_prompt", load_prompt("system"))
+    return merged

--- a/src/packages/orchestrator/prompts/__init__.py
+++ b/src/packages/orchestrator/prompts/__init__.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Mapping
+
+_PROMPT_DIR = Path(__file__).resolve().parent
+
+
+@lru_cache(maxsize=None)
+def load_prompt(name: str) -> str:
+    path = _PROMPT_DIR / f"{name}.md"
+    return path.read_text(encoding="utf-8").strip()
+
+
+def render_prompt(name: str, values: Mapping[str, str]) -> str:
+    template = load_prompt(name)
+    return template.format_map(_SafeDict(values))
+
+
+def synthesis_headers() -> list[str]:
+    template = load_prompt("synthesis")
+    headers = []
+    for line in template.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("## "):
+            headers.append(stripped)
+    return headers
+
+
+class _SafeDict(dict):
+    def __missing__(self, key: str) -> str:
+        return ""

--- a/src/packages/orchestrator/prompts/citation.md
+++ b/src/packages/orchestrator/prompts/citation.md
@@ -1,0 +1,1 @@
+- [{index}] {title} — {url}

--- a/src/packages/orchestrator/prompts/self_check.md
+++ b/src/packages/orchestrator/prompts/self_check.md
@@ -1,0 +1,2 @@
+I don't have enough evidence to support an answer yet. Please share more context
+or sources so I can help responsibly.

--- a/src/packages/orchestrator/prompts/synthesis.md
+++ b/src/packages/orchestrator/prompts/synthesis.md
@@ -1,0 +1,14 @@
+## Explanation
+{explanation}
+
+## Steps
+{steps}
+
+## Worked Example
+{example}
+
+## Self-Check Questions
+{self_check}
+
+## Sources
+{sources}

--- a/src/packages/orchestrator/prompts/system.md
+++ b/src/packages/orchestrator/prompts/system.md
@@ -1,0 +1,2 @@
+You are a homework coach. Provide guided explanations, not just final answers.
+Always cite sources and avoid large verbatim excerpts.

--- a/src/tests/unit/test_prompts.py
+++ b/src/tests/unit/test_prompts.py
@@ -1,0 +1,21 @@
+from packages.orchestrator.prompts import load_prompt, render_prompt, synthesis_headers
+
+
+def test_load_prompt_reads_template() -> None:
+    content = load_prompt("system")
+    assert "homework coach" in content.lower()
+
+
+def test_render_prompt_formats_values() -> None:
+    rendered = render_prompt(
+        "citation",
+        {"index": "1", "title": "Example", "url": "https://example.com"},
+    )
+    assert "Example" in rendered
+    assert "https://example.com" in rendered
+
+
+def test_synthesis_headers_extracts_titles() -> None:
+    headers = synthesis_headers()
+    assert "## Explanation" in headers
+    assert "## Sources" in headers

--- a/src/tests/unit/test_self_check_node.py
+++ b/src/tests/unit/test_self_check_node.py
@@ -5,10 +5,10 @@ def test_self_check_removes_unsupported_claims() -> None:
     state = {
         "draft_answer": "\n".join(
             [
-                "Explanation",
+                "## Explanation",
                 "Photosynthesis converts light energy into chemical energy.",
                 "It happens on Mars.",
-                "Sources",
+                "## Sources",
             ]
         ),
         "evidence": [
@@ -29,8 +29,8 @@ def test_self_check_removes_unsupported_claims() -> None:
         "Photosynthesis converts light energy into chemical energy."
         in result["final_answer"]
     )
-    assert "Explanation" in result["final_answer"]
-    assert "Sources" in result["final_answer"]
+    assert "## Explanation" in result["final_answer"]
+    assert "## Sources" in result["final_answer"]
     assert result["diagnostics"]["unsupported_claims"] == ["It happens on Mars."]
 
 

--- a/src/tests/unit/test_synthesize_node.py
+++ b/src/tests/unit/test_synthesize_node.py
@@ -26,8 +26,8 @@ def test_synthesize_builds_answer_and_citations() -> None:
     assert "final_answer" in result
     assert "citations" in result
     assert len(result["citations"]) == 2
-    assert "Explanation" in result["final_answer"]
-    assert "Sources" in result["final_answer"]
+    assert "## Explanation" in result["final_answer"]
+    assert "## Sources" in result["final_answer"]
     assert (
         "[wikipedia:https://en.wikipedia.org/wiki/Photosynthesis]"
         in result["final_answer"]


### PR DESCRIPTION
Added prompt templates and wired nodes to load/render them instead of inline prompt text. Synthesis now renders from synthesis.md and citation lines use citation.md; self-check uses self_check.md for the fallback message and pulls section headers from the synthesis template.