### PR TITLE
Implemented the /api/v1/chat endpoint

### DIFF
--- a/docs/tasks/5-02.md
+++ b/docs/tasks/5-02.md
@@ -1,0 +1,10 @@
+**Implement Chat endpoint**
+  - File: `apps/assistant_api/src/api/v1/chat.py`
+  - **Cursor prompt:**  
+    - Implement `POST /api/v1/chat` accepting `{question, context}` and returning `{answer, citations, diagnostics}`. Handle partial retrieval failures gracefully.
+    - Always write unit tests for the code in a task.
+    - Automatically run unit tests after task is complete.
+    - Automatically run format and style tools by using `.cursor/rules/80-code-style-python.mdc` 
+  - **Definition of Done:** 
+    - endpoint triggers the LangGraph and returns JSON.
+    - all unit tests and linters (ruff, mypy) must pass successfully.

--- a/src/apps/assistant_api/api/v1/chat.py
+++ b/src/apps/assistant_api/api/v1/chat.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+
+from apps.assistant_api.dependencies import get_orchestrator
+
+router = APIRouter(prefix="/api/v1")
+
+
+class ChatRequest(BaseModel):
+    question: str = Field(..., min_length=1)
+    context: dict[str, Any] | None = None
+
+
+class ChatResponse(BaseModel):
+    answer: str
+    citations: list[dict[str, Any]]
+    diagnostics: dict[str, Any] = Field(default_factory=dict)
+    safety_flags: list[str] = Field(default_factory=list)
+
+
+OrchestratorFn = Callable[[str, Mapping[str, object] | None], Mapping[str, object]]
+
+
+@router.post("/chat", response_model=ChatResponse)
+def chat(
+    payload: ChatRequest,
+    orchestrator: OrchestratorFn = Depends(get_orchestrator),
+) -> ChatResponse:
+    context = payload.context or {}
+    result = orchestrator(payload.question, context or None)
+    diagnostics = _coerce_dict(result.get("diagnostics"))
+    errors = _coerce_list_of_str(diagnostics.get("errors"))
+    if errors:
+        diagnostics["errors"] = errors
+    return ChatResponse(
+        answer=str(result.get("final_answer") or ""),
+        citations=_coerce_dict_list(result.get("citations")),
+        diagnostics=diagnostics,
+        safety_flags=_coerce_str_list(result.get("safety_flags")),
+    )
+
+
+def _coerce_dict_list(value: object) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, dict)]
+    return []
+
+
+def _coerce_dict(value: object) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return dict(value)
+    return {}
+
+
+def _coerce_str_list(value: object) -> list[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item)]
+    return []
+
+
+def _coerce_list_of_str(value: object) -> list[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item)]
+    return []

--- a/src/apps/assistant_api/dependencies.py
+++ b/src/apps/assistant_api/dependencies.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import Callable, Mapping
+
+from packages.orchestrator.graph.build_graph import run as run_orchestrator
+
+OrchestratorFn = Callable[[str, Mapping[str, object] | None], Mapping[str, object]]
+
+
+def get_orchestrator() -> OrchestratorFn:
+    return run_orchestrator

--- a/src/apps/assistant_api/main.py
+++ b/src/apps/assistant_api/main.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass
-from typing import Any, Callable, Mapping
+from typing import Callable, Mapping
 
-from fastapi import Depends, FastAPI
-from pydantic import BaseModel, Field
+from fastapi import FastAPI
 
-from packages.orchestrator.graph.build_graph import run as run_orchestrator
+from apps.assistant_api.api.v1.chat import router as chat_router
 
 logger = logging.getLogger(__name__)
 
@@ -35,23 +34,7 @@ def configure_logging(settings: Settings) -> None:
     )
 
 
-class ChatRequest(BaseModel):
-    question: str = Field(..., min_length=1)
-    student_context: dict[str, Any] | None = None
-
-
-class ChatResponse(BaseModel):
-    answer: str
-    citations: list[dict[str, Any]]
-    diagnostics: dict[str, Any] = Field(default_factory=dict)
-    safety_flags: list[str] = Field(default_factory=list)
-
-
 OrchestratorFn = Callable[[str, Mapping[str, object] | None], Mapping[str, object]]
-
-
-def get_orchestrator() -> OrchestratorFn:
-    return run_orchestrator
 
 
 def create_app() -> FastAPI:
@@ -63,41 +46,9 @@ def create_app() -> FastAPI:
     def health() -> dict[str, str]:
         return {"status": "ok"}
 
-    @app.post("/api/v1/chat", response_model=ChatResponse)
-    def chat(
-        payload: ChatRequest,
-        orchestrator: OrchestratorFn = Depends(get_orchestrator),
-    ) -> ChatResponse:
-        context: dict[str, object] = {}
-        if payload.student_context:
-            context["student_context"] = payload.student_context
-        result = orchestrator(payload.question, context or None)
-        return ChatResponse(
-            answer=str(result.get("final_answer") or ""),
-            citations=_coerce_dict_list(result.get("citations")),
-            diagnostics=_coerce_dict(result.get("diagnostics")),
-            safety_flags=_coerce_str_list(result.get("safety_flags")),
-        )
+    app.include_router(chat_router)
 
     return app
 
 
 app = create_app()
-
-
-def _coerce_dict_list(value: object) -> list[dict[str, Any]]:
-    if isinstance(value, list):
-        return [item for item in value if isinstance(item, dict)]
-    return []
-
-
-def _coerce_dict(value: object) -> dict[str, Any]:
-    if isinstance(value, dict):
-        return dict(value)
-    return {}
-
-
-def _coerce_str_list(value: object) -> list[str]:
-    if isinstance(value, list):
-        return [str(item) for item in value if str(item)]
-    return []

--- a/src/tests/unit/test_api_app.py
+++ b/src/tests/unit/test_api_app.py
@@ -4,7 +4,8 @@ from typing import Mapping
 
 from fastapi.testclient import TestClient
 
-from apps.assistant_api.main import create_app, get_orchestrator
+from apps.assistant_api.dependencies import get_orchestrator
+from apps.assistant_api.main import create_app
 
 
 def test_health_endpoint() -> None:
@@ -24,11 +25,11 @@ def test_chat_endpoint_uses_orchestrator() -> None:
         question: str, context: Mapping[str, object] | None
     ) -> Mapping[str, object]:
         assert question == "What is inertia?"
-        assert context == {"student_context": {"subject": "physics"}}
+        assert context == {"subject": "physics"}
         return {
             "final_answer": "Inertia is resistance to changes in motion.",
             "citations": [{"source": "wikipedia", "locator": "https://example.com"}],
-            "diagnostics": {"note": "ok"},
+            "diagnostics": {"note": "ok", "errors": ["partial_stackoverflow"]},
             "safety_flags": ["coach"],
         }
 
@@ -39,7 +40,7 @@ def test_chat_endpoint_uses_orchestrator() -> None:
         "/api/v1/chat",
         json={
             "question": "What is inertia?",
-            "student_context": {"subject": "physics"},
+            "context": {"subject": "physics"},
         },
     )
 
@@ -48,4 +49,5 @@ def test_chat_endpoint_uses_orchestrator() -> None:
     assert payload["answer"].startswith("Inertia")
     assert payload["citations"]
     assert payload["diagnostics"]["note"] == "ok"
+    assert payload["diagnostics"]["errors"] == ["partial_stackoverflow"]
     assert payload["safety_flags"] == ["coach"]


### PR DESCRIPTION
Implemented the /api/v1/chat endpoint in chat.py, added a shared dependencies module to avoid circular imports, and updated the existing API tests to hit the new payload shape and diagnostics error propagation.